### PR TITLE
Mask escape key when pressed to cancel one shot

### DIFF
--- a/src/Kaleidoscope/Escape-OneShot.cpp
+++ b/src/Kaleidoscope/Escape-OneShot.cpp
@@ -38,6 +38,8 @@ Key EscapeOneShot::eventHandlerHook(Key mapped_key, byte row, byte col, uint8_t 
   if (!::OneShot.isActive())
     return mapped_key;
 
+  KeyboardHardware.maskKey(row, col);
+
   ::OneShot.cancel();
 
   return Key_NoKey;


### PR DESCRIPTION
Previously, when pressing the escape key to cancel a one shot, escape would still be sent, which isn't the expected behaviour. This PR fixes this issue.